### PR TITLE
feat: setup ping page

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,1 +1,2 @@
 <a href="/hello">Hello World!</a>
+<a href="/ping">Ping</a>

--- a/frontend/src/routes/ping/+page.svelte
+++ b/frontend/src/routes/ping/+page.svelte
@@ -1,0 +1,20 @@
+<script>
+    async function getPing() {
+        const res = await fetch("/api/ping")
+        const data = await res.json()
+
+        if(!data.message){
+            return "Error, no pong!"
+        }
+
+        return data.message
+    }
+</script>
+
+<a href="/">Home</a>
+
+{#await getPing() then message}
+    <h1 class="text-3xl font-bold">{message}!</h1>
+    {:catch error}
+    <p>Error: API is not running or not reachable</p>
+{/await}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,5 +2,16 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-	plugins: [sveltekit()]
+	plugins: [sveltekit()],
+	server: {
+		host: true,
+		port: 8001,
+		proxy: {
+			"/api": {
+				target: "http://localhost:8000",
+				changeOrigin: true,
+				secure: false
+			}
+		}
+	}
 });


### PR DESCRIPTION
closes #17 

To review PR:
- CD into frontend
- Run: `npm run dev`
- In browser, go to `http://localhost:8001/ping`
- Should be able to see "PONG"
  - otherwise, you'll see some error message
  
Notes:
- To avoid CORS issue, I setup proxy via `vite.config.js` settings