### PR TITLE
feature(backend): add GET /api/quizzes/{objectId} endpoint

### DIFF
--- a/backend/quizapp/crud.py
+++ b/backend/quizapp/crud.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
-
+from bson import ObjectId
+from fastapi import HTTPException, status
 from motor.motor_asyncio import AsyncIOMotorCollection
 
 
@@ -21,6 +22,13 @@ async def retrieve_quizzes(quiz_collection: AsyncIOMotorCollection) -> list[dict
     async for quiz in quiz_collection.find():
         quizzes.append(quiz_helper(quiz))
     return quizzes
+
+
+async def retrieve_quiz(quiz_collection: AsyncIOMotorCollection, quiz_id: str) -> dict:
+    quiz = await quiz_collection.find_one({"_id": ObjectId(quiz_id)})
+    if not quiz:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    return quiz_helper(quiz)
 
 
 async def insert_quiz_to_db(

--- a/backend/quizapp/crud.py
+++ b/backend/quizapp/crud.py
@@ -1,6 +1,8 @@
 from datetime import datetime
+from uu import Error
 
 from bson import ObjectId
+from bson.errors import InvalidId
 from fastapi import HTTPException, status
 from motor.motor_asyncio import AsyncIOMotorCollection
 
@@ -25,10 +27,19 @@ async def retrieve_quizzes(quiz_collection: AsyncIOMotorCollection) -> list[dict
 
 
 async def retrieve_quiz(quiz_collection: AsyncIOMotorCollection, quiz_id: str) -> dict:
-    quiz = await quiz_collection.find_one({"_id": ObjectId(quiz_id)})
-    if not quiz:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
-    return quiz_helper(quiz)
+    try:
+        _id = ObjectId(quiz_id)
+        quiz = await quiz_collection.find_one({"_id": _id})
+        if not quiz:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"No quizzes exist with the ID {_id}",
+            )
+        return quiz_helper(quiz)
+    except InvalidId:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid MongoDB ID"
+        )
 
 
 async def insert_quiz_to_db(

--- a/backend/quizapp/routers/quizzes.py
+++ b/backend/quizapp/routers/quizzes.py
@@ -4,7 +4,7 @@ import motor.motor_asyncio as motor
 from fastapi import APIRouter, Depends, Request, status
 from fastapi.encoders import jsonable_encoder
 
-from ..crud import insert_quiz_to_db, retrieve_quizzes
+from ..crud import insert_quiz_to_db, retrieve_quiz, retrieve_quizzes
 from ..schemas.quiz import QuizSchema
 
 router = APIRouter(tags=["Quizzes"])
@@ -32,3 +32,13 @@ async def get_quizzes(
     ],
 ):
     return await retrieve_quizzes(quiz_collection)
+
+
+@router.get("/{quiz_id}")
+async def get_quiz(
+    quiz_id: str,
+    quiz_collection: Annotated[
+        motor.AsyncIOMotorCollection, Depends(get_quiz_collection)
+    ],
+):
+    return await retrieve_quiz(quiz_collection, quiz_id)

--- a/backend/tests/routers/test_quizzes.py
+++ b/backend/tests/routers/test_quizzes.py
@@ -37,11 +37,22 @@ def test_create_and_get_quiz(test_client, quiz_payload) -> None:
 
 
 def test_get_quiz_not_found(test_client):
-    fake_quiz_id = "12345"
-    response = test_client.get(f"/api/users/{fake_quiz_id}")
+    non_existent_quiz_id = "64e16f8a2f9b1c3d4e5a6b7c"
+    response = test_client.get(f"/api/quizzes/{non_existent_quiz_id}")
     assert response.status_code == 404
     response_json = response.json()
-    assert response_json["detail"] == "Not Found"
+    assert (
+        response_json["detail"]
+        == f"No quizzes exist with the ID {non_existent_quiz_id}"
+    )
+
+
+def test_get_quiz_invalid_id(test_client):
+    invalid_quiz_id = "12345"
+    response = test_client.get(f"/api/quizzes/{invalid_quiz_id}")
+    assert response.status_code == 400
+    response_json = response.json()
+    assert response_json["detail"] == "Invalid MongoDB ID"
 
 
 def test_create_quiz_with_wrong_payload(test_client) -> None:

--- a/backend/tests/routers/test_quizzes.py
+++ b/backend/tests/routers/test_quizzes.py
@@ -22,6 +22,28 @@ def test_create_and_get_quizzes(test_client, quiz_payload) -> None:
     assert len(response.json()) == 2
 
 
+def test_create_and_get_quiz(test_client, quiz_payload) -> None:
+    # Create quiz and save id
+    response: Response = test_client.post("/api/quizzes/", json=quiz_payload)
+    quiz_id = response.json().pop("id")
+
+    # Get quiz by id
+    response: Response = test_client.get(f"/api/quizzes/{quiz_id}")
+    assert response.status_code == 200
+    response_json = response.json()
+    assert response_json.pop("id")
+    assert response_json.pop("created_at")
+    assert response_json == quiz_payload
+
+
+def test_get_quiz_not_found(test_client):
+    fake_quiz_id = "12345"
+    response = test_client.get(f"/api/users/{fake_quiz_id}")
+    assert response.status_code == 404
+    response_json = response.json()
+    assert response_json["detail"] == "Not Found"
+
+
 def test_create_quiz_with_wrong_payload(test_client) -> None:
     response: Response = test_client.post("/api/quizzes/", json={})
     assert response.status_code == 422


### PR DESCRIPTION
This PR introduces a new API endpoint to fetch a quiz by its unique `ObjectId`. The endpoint returns a quiz document from the database if it exists and returns `404 Not Found` if no quiz matches the `ObjectId`.   

**Changes introduced:**
- Added a new route GET `/api/quizzes/{objectId}` to retrieve a quiz by its unique ID
- Integrated MongoDB query to fetch the quiz document based on the provided `ObjectId`
- Included unit tests to validate the endpoint's functionality